### PR TITLE
Clearer readme instructions and rmv mills abs file path from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ a proof of concept for self hosting streaming radio.
 
 [come and check it out!](http://radio.yomills.com)
 
-## example 
+## example
 
 ![example stream](example.png)
 
@@ -12,15 +12,15 @@ a proof of concept for self hosting streaming radio.
 
 ### stream
 
-to start radio stream, populate `stream/audio` directory with mp3 files. then run:
+to start radio stream, `mkdir stream/assets/audio` and populate the directory with mp3 files. then run:
 
 ```
-cd stream2
+cd stream
 npm install
 node index.js
 ```
 
-### backend 
+### backend
 
 ```
 cd server

--- a/README.md
+++ b/README.md
@@ -12,9 +12,19 @@ a proof of concept for self hosting streaming radio.
 
 ### setup
 
+#### ffmpeg
+
 before anything else, you'll need FFMPEG locally. if you don't already, run `brew install ffmpeg` to install it locally.
 
 you may run into a somewhat-common issue of the install failing when building symlinks, which is [fixed in this GitHub thread](https://github.com/Homebrew/homebrew-core/issues/30652#issuecomment-410645836).
+
+#### env files
+
+in the client, server, and stream directories, you'll find `.env.example` files. create a new `.env` file for each directory and copy the content of the `.env.example`.
+
+#### audio files
+
+to populate your radio stream, `mkdir stream/assets/audio` and fill the directory with mp3 files of your choosing.
 
 ### backend
 
@@ -26,8 +36,6 @@ node index.js
 ```
 
 ### stream
-
-to start your radio stream, `mkdir stream/assets/audio` and populate the directory with mp3 files. then run:
 
 ```
 cd stream

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ before anything else, you'll need FFMPEG locally. if you don't already, run `bre
 
 you may run into a somewhat-common issue of the install failing when building symlinks, which is [fixed in this GitHub thread](https://github.com/Homebrew/homebrew-core/issues/30652#issuecomment-410645836).
 
+### backend
+
+```
+cd server
+npm install
+./node_modules/.bin/knex migrate:latest
+node index.js
+```
+
 ### stream
 
 to start your radio stream, `mkdir stream/assets/audio` and populate the directory with mp3 files. then run:
@@ -23,15 +32,6 @@ to start your radio stream, `mkdir stream/assets/audio` and populate the directo
 ```
 cd stream
 npm install
-node index.js
-```
-
-### backend
-
-```
-cd server
-npm install
-./node_modules/.bin/knex migrate:latest
 node index.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ a proof of concept for self hosting streaming radio.
 
 ## usage
 
-### stream
+### setup
 
 before anything else, you'll need FFMPEG locally. if you don't already, run `brew install ffmpeg` to install it locally.
+
+you may run into a somewhat-common issue of the install failing when building symlinks, which is [fixed in this GitHub thread](https://github.com/Homebrew/homebrew-core/issues/30652#issuecomment-410645836).
+
+### stream
 
 to start your radio stream, `mkdir stream/assets/audio` and populate the directory with mp3 files. then run:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ a proof of concept for self hosting streaming radio.
 
 ### stream
 
-to start radio stream, `mkdir stream/assets/audio` and populate the directory with mp3 files. then run:
+before anything else, you'll need FFMPEG locally. if you don't already, run `brew install ffmpeg` to install it locally.
+
+to start your radio stream, `mkdir stream/assets/audio` and populate the directory with mp3 files. then run:
 
 ```
 cd stream

--- a/stream/config.json
+++ b/stream/config.json
@@ -1,6 +1,6 @@
 {
-  "VIDEO_PATH": "/Users/mills/projects/radio/stream/assets/video/dock.mp4",
-  "AUDIO_PATH": "/Users/mills/projects/radio/stream/assets/audio/",
+  "VIDEO_PATH": "./assets/video/dock.mp4",
+  "AUDIO_PATH": "./assets/audio/",
   "FFMPEG_PATH": "",
   "STREAM_URL": "rtmp://localhost/live/opensourceradio",
 


### PR DESCRIPTION
- Updated VIDEO_PATH and AUDIO_PATH in stream/config to be relative paths instead of mills paths
- Updated README with clearer audio upload instructions, ffmpeg setup, and better ordering to avoid failed stream process